### PR TITLE
Modified snmpd.conf.erb to prevent the config file from changing order for subsequent puppet runs.

### DIFF
--- a/templates/snmpd.conf.erb
+++ b/templates/snmpd.conf.erb
@@ -10,5 +10,5 @@ sysLocation <%= scope.lookupvar('snmpd::snmplocation') %>
 sysContact <%= scope.lookupvar('snmpd::snmpcontact') %>
 
 # The following is generated from snmpd::options
-<% scope.lookupvar('snmpd::options').each_pair do |key, value| %><%= key %> <%= value %> 
+<% scope.lookupvar('snmpd::options').sort.each do |option| %><%= option.first %> <%= option.last %> 
 <% end %>


### PR DESCRIPTION
Most useful for environments using a ruby version older than 1.9, where hash order isn't guaranteed
Will order the ruby hash of snmpd options alphabetically. Tested on a system running Puppet 3.7.3 and Ruby 1.8.7.